### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,3 +1,0 @@
-- name: Office
-  tocHref: /
-  topicHref: /

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -101,7 +101,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/open-xml-docs-ref-dotnet-breadcrumb/toc.json",
       "uhfHeaderId": "MSDocsHeader-Dev_Office",
       "ms.suite": "office365",
       "ms.author": "o365devx",

--- a/docs/open-xml-docs-ref-dotnet-breadcrumb/toc.yml
+++ b/docs/open-xml-docs-ref-dotnet-breadcrumb/toc.yml
@@ -1,0 +1,11 @@
+- name: Microsoft 365
+  tocHref: /dotnet/
+  topicHref: /microsoft-365/index
+  items:
+  - name: Office Add-ins
+    tocHref: /dotnet/
+    topicHref: /office/dev/add-ins/index
+    items:
+    - name: .NET API browser
+      tocHref: /dotnet/
+      topicHref: /dotnet/api/index


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.